### PR TITLE
Added IBM cloud CLI config to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,6 +58,11 @@ Vagrant.configure(2) do |config|
     config.vm.provision "file", source: "~/.vimrc", destination: "~/.vimrc"
   end
 
+  # Copy your IBM Clouid API Key if you have one
+  if File.exists?(File.expand_path("~/.bluemix/apiKey.json"))
+    config.vm.provision "file", source: "~/.bluemix/apiKey.json", destination: "~/.bluemix/apiKey.json"
+  end
+
   ######################################################################
   # Create a Python 3 development environment
   ######################################################################
@@ -91,5 +96,30 @@ Vagrant.configure(2) do |config|
     d.run "postgres:alpine",
        args: "-d --name postgres -p 5432:5432 -v psql_data:/var/lib/postgresql/data -e POSTGRES_PASSWORD=postgres"
   end
+
+  ######################################################################
+  # Setup a Bluemix environment
+  ######################################################################
+  config.vm.provision "shell", inline: <<-SHELL
+    echo "\n************************************"
+    echo " Installing IBM Cloud CLI..."
+    echo "************************************\n"
+    # Install IBM Cloud CLI as Vagrant user
+    sudo -H -u vagrant sh -c '
+    curl -fsSL https://clis.cloud.ibm.com/install/linux | sh && \
+    ibmcloud cf install && \
+    echo "alias ic=ibmcloud" >> ~/.bashrc
+    '
+    # Show completion instructions
+    sudo -H -u vagrant sh -c "echo alias ic=/usr/local/bin/ibmcloud >> ~/.bash_aliases"
+    echo "\n************************************"
+    echo "If you have an IBM Cloud API key in ~/.bluemix/apiKey.json"
+    echo "You can login with the following command:"
+    echo "\n"
+    echo "ibmcloud login -a https://cloud.ibm.com --apikey @~/.bluemix/apiKey.json -r us-south"
+    echo "ibmcloud target --cf -o <your_org_here> -s dev"
+    echo "\n************************************"
+  SHELL
+
 
 end


### PR DESCRIPTION
Prerequisite: Download your API keys from IBM cloud and add them to your local .bluemix/ folder before running "vagrant up"